### PR TITLE
fix: auto update asset

### DIFF
--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -3,7 +3,7 @@ name: Update Assets
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0,2,4,6,8,10,12,14,16,18,20,22 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
   build:
@@ -17,8 +17,12 @@ jobs:
         with:
           python-version: '3.10'
           architecture: x64
+          cache: pip
       - name: Install dependencies
-        run: pip install requests requests_cache
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          sudo apt-get install unrar
       - name: Update Assets
         run: |
           python update.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests_cache
+patool


### PR DESCRIPTION
- 尝试修了自动更新，使用`patool`库来避免不同压缩格式的干扰
  - [解压rar例子](https://github.com/Zebartin/AzurLaneUncensored/actions/runs/6010391730/job/16301708435)：相应的commit被我force push覆盖了
  - [解压zip例子](https://github.com/Zebartin/AzurLaneUncensored/actions/runs/6010468318/job/16301952237)：临时改了代码，下载原反和谐仓库zip源码并解压，列出文件列表
- 另外感觉2小时的频率有点高，改成一天一次